### PR TITLE
docs: updated typo in getting started

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -110,7 +110,7 @@ Before interacting with a provider, initialization is necessary. Each provider r
 ```typescript
 import GoogleAuthClient from '@openmobilehub/auth-google';
 
-await GoogleAuth.initialize({
+await GoogleAuthClient.initialize({
   android: {
     scopes: ['openid', 'profile', 'email'],
     webClientId: GOOGLE_WEB_CLIENT_ID,


### PR DESCRIPTION
## Summary

Updated typo in the getting started guide.
Related to this issue: [#90](https://github.com/openmobilehub/react-native-omh-auth/issues/90)
Fixes #90 

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [ ] Created Unit tests
